### PR TITLE
Fix applicant normalization candidate id handling

### DIFF
--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -311,14 +311,22 @@ export function normalizeApplicantRecord(record, { job = null } = {}) {
     normalizeLookup(record?.Application_Name, { primitive: "name" }),
     normalizeLookup(record?.Application_Id, { primitive: "id" })
   );
+  const candidateLookup = mergeLookups(
+    normalizeLookup(record?.Candidate),
+    normalizeLookup(record?.Candidate_Name, { primitive: "name" }),
+    normalizeLookup(record?.Candidate_Id, { primitive: "id" })
+  );
   const applicationId = applicationLookup?.id ?? firstDefined(record?.id, record?.ID, record?.Application_ID, record?.Application_Id, null) ?? null;
   const candidate = normalizeCandidateRecord(record, { attachments: [], job });
+  const candidateId = candidateLookup?.id ?? candidate.id ?? null;
 
   return {
     ...candidate,
+    candidateId,
     applicationId,
     reviewPayload: {
       ...candidate.reviewPayload,
+      candidateId,
       applicationId,
       jobId: job?.id || candidate.jobOpening?.id || null
     }

--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -318,7 +318,7 @@ export function normalizeApplicantRecord(record, { job = null } = {}) {
   );
   const applicationId = applicationLookup?.id ?? firstDefined(record?.id, record?.ID, record?.Application_ID, record?.Application_Id, null) ?? null;
   const candidate = normalizeCandidateRecord(record, { attachments: [], job });
-  const candidateId = candidateLookup?.id ?? candidate.id ?? null;
+  const candidateId = candidateLookup?.id ?? null;
 
   return {
     ...candidate,

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -71,6 +71,22 @@ test("normalizeApplicantRecord falls back to the internal application record id"
   assert.equal(applicant.applicationId, "850051000000588062");
 });
 
+test("normalizeApplicantRecord preserves the related candidate record id separately from the application id", async () => {
+  const { normalizeApplicantRecord } = await importFresh("../api/recruit/_normalize.js");
+  const applicant = normalizeApplicantRecord({
+    id: "850051000000588062",
+    Application_ID: "ZR_8_APP",
+    Candidate: { id: "850051000000577777", name: "Jacoby Curry" },
+    Full_Name: "Jacoby Curry",
+    Email: "coby@example.com",
+    Application_Status: "Applied"
+  });
+
+  assert.equal(applicant.applicationId, "850051000000588062");
+  assert.equal(applicant.candidateId, "850051000000577777");
+  assert.equal(applicant.reviewPayload.candidateId, "850051000000577777");
+});
+
 test("listJobApplicants falls back to Applications when Zoho rejects job candidate relations", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -69,6 +69,8 @@ test("normalizeApplicantRecord falls back to the internal application record id"
   });
 
   assert.equal(applicant.applicationId, "850051000000588062");
+  assert.equal(applicant.candidateId, null);
+  assert.equal(applicant.reviewPayload.candidateId, null);
 });
 
 test("normalizeApplicantRecord preserves the related candidate record id separately from the application id", async () => {


### PR DESCRIPTION
## What changed
- keep the related candidate record id separate from the application id during applicant normalization
- propagate `candidateId` into the normalized applicant record and `reviewPayload`
- add a regression test for records that contain both application and candidate identifiers

## Why
The applicant-normalization path could collapse the candidate id into the application id, which breaks downstream consumers that need the real candidate record id for follow-up detail fetches.

## Risk / tradeoffs
- low risk; this is a narrow normalization fix with targeted coverage
- downstream code will now see a distinct `candidateId` when Zoho provides it

## How verified
- `node --check api/recruit/_normalize.js`
- `node --check tests/job-applicants.test.js`
- `node --test tests/job-applicants.test.js`

## Notes
- excluded local runtime artifacts: `.ai/`
- AI-assisted change and review
