### PR TITLE
feat: add Zoho resume content endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Generic Zoho Recruit OAuth + API bridge for OpenClaw workflows.
 - `GET /api/recruit/jobs/:jobId/applicants` (protected)
 - `GET /api/recruit/candidates/:candidateId` (protected)
 - `GET /api/recruit/candidates/:candidateId/resume` (protected)
+- `GET /api/recruit/candidates/:candidateId/resume-content` (protected)
 - `POST /api/recruit/applications/:applicationId/decision` (protected)
 - `POST /api/recruit/candidates/:candidateId/decision` (protected)
 - `POST /api/recruit/applications/:applicationId/notes` (protected)
@@ -37,6 +38,7 @@ Query and payload notes:
 - `GET /api/recruit/jobs/:jobId/applicants?page=1&perPage=50` lists associated candidates/applicants.
 - `GET /api/recruit/candidates/:candidateId?applicationId=<applicationId>&jobId=<jobId>` adds optional application/job context.
 - `GET /api/recruit/candidates/:candidateId/resume?applicationId=<applicationId>` returns candidate attachments plus optional application attachments.
+- `GET /api/recruit/candidates/:candidateId/resume-content?applicationId=<applicationId>&attachmentId=<attachmentId>` returns base64-encoded bytes for the selected resume attachment, defaulting to the primary resume.
 - Decision endpoints accept `decision`, optional `target.stage` / `target.status`, reviewer metadata, scorecards, rationale, external sync metadata, and `idempotencyKey` / `sourceRunId`.
 - Note endpoints accept plain `content` or the same structured review metadata used by decision writes.
 - The application patch endpoint accepts `{ "fields": { ... } }` plus optional `trigger`, `idempotencyKey`, and `sourceRunId`.

--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -91,6 +91,11 @@ export function normalizeAttachmentRecord(record, { moduleApiName, recordId, rec
   };
 }
 
+export function isResumeAttachment(attachment) {
+  const name = `${attachment?.category || ""} ${attachment?.fileName || ""}`.toLowerCase();
+  return /(resume|curriculum vitae|\bcv\b)/.test(name);
+}
+
 export function normalizeNoteRecord(record, { parentId = null, seModule = null, title = null, content = null } = {}) {
   return {
     id: firstDefined(record?.id, record?.ID, record?.details?.id, null)?.toString() || null,
@@ -121,15 +126,17 @@ export function normalizeNoteRecord(record, { parentId = null, seModule = null, 
 }
 
 export function selectPrimaryResume(attachments) {
-  const ranked = [...attachments].sort((left, right) => {
-    const leftName = `${left.category || ""} ${left.fileName || ""}`.toLowerCase();
-    const rightName = `${right.category || ""} ${right.fileName || ""}`.toLowerCase();
-    const leftScore = /(resume|cv)/.test(leftName) ? 2 : 0;
-    const rightScore = /(resume|cv)/.test(rightName) ? 2 : 0;
-    const leftTime = Date.parse(left.modifiedTime || left.createdTime || 0) || 0;
-    const rightTime = Date.parse(right.modifiedTime || right.createdTime || 0) || 0;
-    return rightScore - leftScore || rightTime - leftTime;
-  });
+  const ranked = [...attachments]
+    .filter((attachment) => isResumeAttachment(attachment))
+    .sort((left, right) => {
+      const leftName = `${left.category || ""} ${left.fileName || ""}`.toLowerCase();
+      const rightName = `${right.category || ""} ${right.fileName || ""}`.toLowerCase();
+      const leftScore = /(resume|cv)/.test(leftName) ? 2 : 0;
+      const rightScore = /(resume|cv)/.test(rightName) ? 2 : 0;
+      const leftTime = Date.parse(left.modifiedTime || left.createdTime || 0) || 0;
+      const rightTime = Date.parse(right.modifiedTime || right.createdTime || 0) || 0;
+      return rightScore - leftScore || rightTime - leftTime;
+    });
 
   return ranked[0] || null;
 }

--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -126,9 +126,7 @@ export function normalizeNoteRecord(record, { parentId = null, seModule = null, 
 }
 
 export function selectPrimaryResume(attachments) {
-  const ranked = [...attachments]
-    .filter((attachment) => isResumeAttachment(attachment))
-    .sort((left, right) => {
+  const ranked = [...attachments].sort((left, right) => {
       const leftName = `${left.category || ""} ${left.fileName || ""}`.toLowerCase();
       const rightName = `${right.category || ""} ${right.fileName || ""}`.toLowerCase();
       const leftScore = /(resume|cv)/.test(leftName) ? 2 : 0;

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -233,6 +233,53 @@ export async function recruitRequest(path, options = {}) {
   }
 }
 
+async function recruitBinaryRequestOnce(path, { method = "GET", query = {}, token, headers = {} } = {}) {
+  const base = zohoRecruitBase();
+  const url = new URL(`${base}${path.startsWith("/") ? path : `/${path}`}`);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value === undefined || value === null || value === "") continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const requestHeaders = {
+    Authorization: `Zoho-oauthtoken ${token.access_token}`,
+    ...headers
+  };
+
+  const resp = await fetch(url, {
+    method,
+    headers: requestHeaders
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    const payload = parseJson(text);
+    throw classifyRecruitError(resp.status, payload, base, path);
+  }
+
+  const arrayBuffer = await resp.arrayBuffer();
+  return {
+    body: Buffer.from(arrayBuffer),
+    response: resp,
+    url: url.toString(),
+    recruitBase: base
+  };
+}
+
+export async function recruitBinaryRequest(path, options = {}) {
+  let token = options.token || await getValidToken();
+
+  try {
+    return await recruitBinaryRequestOnce(path, { ...options, token });
+  } catch (error) {
+    const shouldRetry = error?.type === "auth" && token?.refresh_token;
+    if (!shouldRetry) throw error;
+
+    token = await requestAccessTokenRefresh(token);
+    return recruitBinaryRequestOnce(path, { ...options, token });
+  }
+}
+
 export async function getRecruitRecord(moduleApiName, recordId) {
   const { payload, recruitBase } = await recruitRequest(`/recruit/v2/${moduleApiName}/${encodeURIComponent(recordId)}`);
   const record = Array.isArray(payload?.data) ? payload.data[0] : payload?.data || null;
@@ -435,6 +482,20 @@ export async function getCandidateResumeArtifacts(candidateId, applicationId = n
     sources: collected,
     attachments,
     primaryResume: selectPrimaryResume(attachments)
+  };
+}
+
+export async function downloadAttachmentContent({ moduleApiName, recordId, attachmentId }) {
+  const { body, response, recruitBase, url } = await recruitBinaryRequest(
+    `/recruit/v2/${moduleApiName}/${encodeURIComponent(recordId)}/Attachments/${encodeURIComponent(attachmentId)}`
+  );
+
+  return {
+    buffer: body,
+    contentType: response.headers.get("content-type") || null,
+    contentDisposition: response.headers.get("content-disposition") || null,
+    recruitBase,
+    url
   };
 }
 

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -251,6 +251,29 @@ async function recruitBinaryRequestOnce(path, { method = "GET", query = {}, toke
     headers: requestHeaders
   });
 
+  const contentType = String(resp.headers.get("content-type") || "").toLowerCase();
+  if (contentType.includes("application/json")) {
+    const text = await resp.text();
+    const payload = parseJson(text);
+    if (!resp.ok) {
+      throw classifyRecruitError(resp.status, payload, base, path);
+    }
+
+    const embeddedError = unwrapRecruitError(payload);
+    if (embeddedError?.status === "error") {
+      throw classifyRecruitError(resp.status >= 400 ? resp.status : 400, payload, base, path);
+    }
+
+    throw buildRecruitError({
+      status: 502,
+      type: "recruit_api",
+      message: "Recruit binary endpoint returned JSON instead of attachment content",
+      recruitBase: base,
+      path,
+      payload
+    });
+  }
+
   if (!resp.ok) {
     const text = await resp.text();
     const payload = parseJson(text);

--- a/api/recruit/candidates/[candidateId]/resume-content.js
+++ b/api/recruit/candidates/[candidateId]/resume-content.js
@@ -1,0 +1,59 @@
+import {
+  firstQueryValue,
+  json,
+  requireSecret
+} from "../../../_lib.js";
+import {
+  downloadAttachmentContent,
+  getCandidateResumeArtifacts,
+  sendApiError
+} from "../../_shared.js";
+
+export default async function handler(req, res) {
+  if (!requireSecret(req)) return json(res, 401, { ok: false, error: "Unauthorized" });
+
+  try {
+    const candidateId = firstQueryValue(req.query.candidateId, null);
+    const applicationId = firstQueryValue(req.query.applicationId, null);
+    const attachmentId = firstQueryValue(req.query.attachmentId, null);
+
+    if (!candidateId) {
+      return json(res, 400, { ok: false, error: { type: "validation", message: "Missing candidateId" } });
+    }
+
+    const artifacts = await getCandidateResumeArtifacts(candidateId, applicationId);
+    const attachment = attachmentId
+      ? artifacts.attachments.find((item) => item.id && String(item.id) === String(attachmentId)) || null
+      : artifacts.primaryResume || null;
+
+    if (!attachment?.id || !attachment.sourceModule || !attachment.sourceRecordId) {
+      return json(res, 404, {
+        ok: false,
+        error: {
+          type: "not_found",
+          message: attachmentId ? "Attachment not found" : "No resume attachment available"
+        }
+      });
+    }
+
+    const content = await downloadAttachmentContent({
+      moduleApiName: attachment.sourceModule,
+      recordId: attachment.sourceRecordId,
+      attachmentId: attachment.id
+    });
+
+    return json(res, 200, {
+      ok: true,
+      candidateId,
+      applicationId,
+      attachment,
+      contentType: content.contentType,
+      contentDisposition: content.contentDisposition,
+      contentBase64: content.buffer.toString("base64"),
+      byteLength: content.buffer.length,
+      recruitBase: content.recruitBase
+    });
+  } catch (error) {
+    return sendApiError(res, error);
+  }
+}

--- a/api/recruit/candidates/[candidateId]/resume-content.js
+++ b/api/recruit/candidates/[candidateId]/resume-content.js
@@ -8,7 +8,6 @@ import {
   getCandidateResumeArtifacts,
   sendApiError
 } from "../../_shared.js";
-import { isResumeAttachment } from "../../_normalize.js";
 
 export default async function handler(req, res) {
   if (!requireSecret(req)) return json(res, 401, { ok: false, error: "Unauthorized" });
@@ -24,7 +23,7 @@ export default async function handler(req, res) {
 
     const artifacts = await getCandidateResumeArtifacts(candidateId, applicationId);
     const attachment = attachmentId
-      ? artifacts.attachments.find((item) => item.id && String(item.id) === String(attachmentId) && isResumeAttachment(item)) || null
+      ? artifacts.attachments.find((item) => item.id && String(item.id) === String(attachmentId)) || null
       : artifacts.primaryResume || null;
 
     if (!attachment?.id || !attachment.sourceModule || !attachment.sourceRecordId) {

--- a/api/recruit/candidates/[candidateId]/resume-content.js
+++ b/api/recruit/candidates/[candidateId]/resume-content.js
@@ -8,6 +8,7 @@ import {
   getCandidateResumeArtifacts,
   sendApiError
 } from "../../_shared.js";
+import { isResumeAttachment } from "../../_normalize.js";
 
 export default async function handler(req, res) {
   if (!requireSecret(req)) return json(res, 401, { ok: false, error: "Unauthorized" });
@@ -23,7 +24,7 @@ export default async function handler(req, res) {
 
     const artifacts = await getCandidateResumeArtifacts(candidateId, applicationId);
     const attachment = attachmentId
-      ? artifacts.attachments.find((item) => item.id && String(item.id) === String(attachmentId)) || null
+      ? artifacts.attachments.find((item) => item.id && String(item.id) === String(attachmentId) && isResumeAttachment(item)) || null
       : artifacts.primaryResume || null;
 
     if (!attachment?.id || !attachment.sourceModule || !attachment.sourceRecordId) {

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -58,6 +58,40 @@ function jsonResponse(payload, { ok = true, status = 200 } = {}) {
   };
 }
 
+function binaryResponse(bytes, { status = 200, contentType = "application/octet-stream" } = {}) {
+  const buffer = Buffer.from(bytes);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return String(name).toLowerCase() === "content-type" ? contentType : null;
+      }
+    },
+    arrayBuffer: async () => buffer
+  };
+}
+
+function createResponseRecorder() {
+  return {
+    code: null,
+    headers: {},
+    body: null,
+    status(code) {
+      this.code = code;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    send(body) {
+      this.body = JSON.parse(body);
+      return this;
+    }
+  };
+}
+
 test("normalizeApplicantRecord falls back to the internal application record id", async () => {
   const { normalizeApplicantRecord } = await importFresh("../api/recruit/_normalize.js");
   const applicant = normalizeApplicantRecord({
@@ -158,6 +192,93 @@ test("listJobApplicants falls back to Applications when Zoho rejects job candida
       assert.equal(result.payload.info.source, "applications_fallback");
       assert.equal(calls.some((url) => url.includes("/Candidates")), true);
       assert.equal(calls.some((url) => url.includes("/associate")), true);
+    });
+  });
+});
+
+
+test("downloadAttachmentContent returns binary resume bytes", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.includes('/Candidates/candidate-123/Attachments') && !value.endsWith('/att-1')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'att-1',
+              File_Name: 'resume.pdf',
+              Attachment_Category: 'Resume',
+              Modified_Time: '2026-04-20 10:00:00'
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      if (value.endsWith('/Candidates/candidate-123/Attachments/att-1')) {
+        return binaryResponse('resume bytes', { contentType: 'application/pdf' });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { downloadAttachmentContent } = await importFresh('../api/recruit/_shared.js');
+      const result = await downloadAttachmentContent({
+        moduleApiName: 'Candidates',
+        recordId: 'candidate-123',
+        attachmentId: 'att-1'
+      });
+
+      assert.equal(result.buffer.toString('utf8'), 'resume bytes');
+      assert.equal(result.contentType, 'application/pdf');
+    });
+  });
+});
+
+test("resume-content handler returns base64 for the primary resume", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: 'access-demo',
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: '9999999999999'
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.includes('/Candidates/candidate-123/Attachments') && !value.endsWith('/att-1')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'att-1',
+              File_Name: 'resume.pdf',
+              Attachment_Category: 'Resume',
+              Modified_Time: '2026-04-20 10:00:00'
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      if (value.endsWith('/Candidates/candidate-123/Attachments/att-1')) {
+        return binaryResponse('resume bytes', { contentType: 'application/pdf' });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { default: handler } = await importFresh('../api/recruit/candidates/[candidateId]/resume-content.js');
+      const req = {
+        query: { candidateId: 'candidate-123' },
+        headers: {}
+      };
+      const res = createResponseRecorder();
+
+      await handler(req, res);
+
+      assert.equal(res.code, 200);
+      assert.equal(res.body.attachment.id, 'att-1');
+      assert.equal(res.body.contentType, 'application/pdf');
+      assert.equal(Buffer.from(res.body.contentBase64, 'base64').toString('utf8'), 'resume bytes');
     });
   });
 });

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -319,7 +319,27 @@ test("resume-content handler returns base64 for the primary resume", async () =>
   });
 });
 
-test("resume-content handler rejects non-resume attachment ids", async () => {
+test("selectPrimaryResume falls back to the newest attachment when no resume keywords match", async () => {
+  const { selectPrimaryResume } = await importFresh("../api/recruit/_normalize.js");
+  const primary = selectPrimaryResume([
+    {
+      id: "att-1",
+      fileName: "candidate-profile.pdf",
+      category: "Documents",
+      modifiedTime: "2026-04-20 10:00:00"
+    },
+    {
+      id: "att-2",
+      fileName: "portfolio.pdf",
+      category: "Documents",
+      modifiedTime: "2026-04-20 11:00:00"
+    }
+  ]);
+
+  assert.equal(primary?.id, "att-2");
+});
+
+test("resume-content handler honors explicit attachment ids with generic names", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: 'access-demo',
     ZOHO_ACCESS_TOKEN_EXPIRES_AT: '9999999999999'
@@ -327,7 +347,7 @@ test("resume-content handler rejects non-resume attachment ids", async () => {
     await withMockFetch(async (url) => {
       const value = String(url);
 
-      if (value.includes('/Candidates/candidate-123/Attachments')) {
+      if (value.includes('/Candidates/candidate-123/Attachments') && !value.endsWith('/att-2')) {
         return jsonResponse({
           data: [
             {
@@ -338,13 +358,17 @@ test("resume-content handler rejects non-resume attachment ids", async () => {
             },
             {
               id: 'att-2',
-              File_Name: 'notes.txt',
-              Attachment_Category: 'Other',
+              File_Name: 'candidate-profile.pdf',
+              Attachment_Category: 'Documents',
               Modified_Time: '2026-04-20 11:00:00'
             }
           ],
           info: { more_records: false }
         });
+      }
+
+      if (value.endsWith('/Candidates/candidate-123/Attachments/att-2')) {
+        return binaryResponse('generic resume bytes', { contentType: 'application/pdf' });
       }
 
       throw new Error(`Unexpected fetch: ${value}`);
@@ -358,9 +382,9 @@ test("resume-content handler rejects non-resume attachment ids", async () => {
 
       await handler(req, res);
 
-      assert.equal(res.code, 404);
-      assert.equal(res.body.ok, false);
-      assert.equal(res.body.error.type, 'not_found');
+      assert.equal(res.code, 200);
+      assert.equal(res.body.attachment.id, 'att-2');
+      assert.equal(Buffer.from(res.body.contentBase64, 'base64').toString('utf8'), 'generic resume bytes');
     });
   });
 });

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -282,3 +282,49 @@ test("resume-content handler returns base64 for the primary resume", async () =>
     });
   });
 });
+
+test("resume-content handler rejects non-resume attachment ids", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: 'access-demo',
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: '9999999999999'
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.includes('/Candidates/candidate-123/Attachments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'att-1',
+              File_Name: 'resume.pdf',
+              Attachment_Category: 'Resume',
+              Modified_Time: '2026-04-20 10:00:00'
+            },
+            {
+              id: 'att-2',
+              File_Name: 'notes.txt',
+              Attachment_Category: 'Other',
+              Modified_Time: '2026-04-20 11:00:00'
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { default: handler } = await importFresh('../api/recruit/candidates/[candidateId]/resume-content.js');
+      const req = {
+        query: { candidateId: 'candidate-123', attachmentId: 'att-2' },
+        headers: {}
+      };
+      const res = createResponseRecorder();
+
+      await handler(req, res);
+
+      assert.equal(res.code, 404);
+      assert.equal(res.body.ok, false);
+      assert.equal(res.body.error.type, 'not_found');
+    });
+  });
+});

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -54,6 +54,11 @@ function jsonResponse(payload, { ok = true, status = 200 } = {}) {
   return {
     ok,
     status,
+    headers: {
+      get(name) {
+        return String(name).toLowerCase() === "content-type" ? "application/json" : null;
+      }
+    },
     text: async () => JSON.stringify(payload)
   };
 }
@@ -234,6 +239,37 @@ test("downloadAttachmentContent returns binary resume bytes", async () => {
 
       assert.equal(result.buffer.toString('utf8'), 'resume bytes');
       assert.equal(result.contentType, 'application/pdf');
+    });
+  });
+});
+
+test("downloadAttachmentContent surfaces embedded Zoho JSON errors", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.endsWith('/Candidates/candidate-123/Attachments/att-1')) {
+        return jsonResponse({
+          status: 'error',
+          code: 'INVALID_DATA',
+          message: 'Attachment is not accessible'
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { downloadAttachmentContent } = await importFresh('../api/recruit/_shared.js');
+      await assert.rejects(
+        () => downloadAttachmentContent({
+          moduleApiName: 'Candidates',
+          recordId: 'candidate-123',
+          attachmentId: 'att-1'
+        }),
+        /Attachment is not accessible/
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a protected `GET /api/recruit/candidates/:candidateId/resume-content` endpoint that returns base64-encoded attachment bytes for the selected or primary resume
- extend the shared Zoho Recruit helper with binary attachment download support and token-refresh retry behavior
- cover the new binary download and resume-content route with node tests

## Why
The resume attachment parsing work in `zoho-attio-recruit-triage` cannot fetch raw Zoho attachment bytes directly without embedding Zoho OAuth into that repo. This keeps the existing bridge-first architecture intact by exposing resume content through the current bridge.

## Testing
- `npm test`

## Post-Deploy Monitoring & Validation
- Log queries/search terms: search bridge logs for `resume-content`, `Unauthorized`, and Zoho attachment download failures on `/api/recruit/candidates/:candidateId/resume-content`
- Metrics or dashboards to watch: request volume, 4xx/5xx rate, and response payload sizes for the new endpoint
- Expected healthy signals: valid internal requests return `200` with `contentBase64`, `contentType`, and the selected attachment metadata; auth refresh retries stay rare
- Failure signals and rollback/mitigation trigger: repeated `401`/`403` responses for valid internal callers, repeated Zoho attachment fetch failures, or unusually large payload spikes; mitigation is reverting the endpoint and falling back to metadata-only enrichment
- Validation window and owner: validate during the first deploy and first live attachment-backed triage run; owner Art/agent operator

## Notes
- Companion change for `zoho-attio-recruit-triage` resume attachment parsing.
