### PR TITLE
fix: recover fallback applicant candidate ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Query and payload notes:
 
 - `GET /api/recruit/jobs?id=<jobId>` fetches one job opening by id.
 - `GET /api/recruit/jobs?title=<exact title>` looks up job openings by exact title.
-- `GET /api/recruit/jobs/:jobId/applicants?page=1&perPage=50` lists associated candidates/applicants.
+- `GET /api/recruit/jobs/:jobId/applicants?page=1&perPage=50` lists associated candidates/applicants. When direct job-applicant relations fail and the bridge falls back to `Applications`, it resolves `candidateId` from exact application email/mobile/phone matches when Zoho candidate lookups are absent.
 - `GET /api/recruit/candidates/:candidateId?applicationId=<applicationId>&jobId=<jobId>` adds optional application/job context.
 - `GET /api/recruit/candidates/:candidateId/resume?applicationId=<applicationId>` returns candidate attachments plus optional application attachments.
 - `GET /api/recruit/candidates/:candidateId/resume-content?applicationId=<applicationId>&attachmentId=<attachmentId>` returns base64-encoded bytes for the selected resume attachment, defaulting to the primary resume.
@@ -92,13 +92,14 @@ If KV is not configured, the OAuth callback returns `manualEnv.ZOHO_REFRESH_TOKE
 
 - Access tokens are loaded from KV when present, otherwise refreshed from `ZOHO_REFRESH_TOKEN` and cached only in memory for the current runtime instance.
 - Recruit errors are normalized into clear JSON types such as `auth`, `scope`, `missing_module`, `not_found`, and `idempotency_conflict`.
+- Applicants fallback rows may include `candidateResolution` metadata showing whether `candidateId` came from an application lookup, exact candidate search, or remained unresolved.
 - Decision endpoints treat `decision` as normalized audit metadata. Actual Recruit stage/status changes come from explicit `target.stage` / `target.status`, extra `fieldValues`, or `ZOHO_RECRUIT_DECISION_FIELD_MAP`; the API does not guess tenant-specific stage names.
 - Decision, note, and patch endpoints support request-level idempotency keyed by `idempotencyKey` or `sourceRunId`. Reusing the same key with a different payload returns `409 idempotency_conflict`.
 - Decision endpoints write a Recruit note by default so downstream CRM sync and audit logging have a durable human-readable trail.
 - Decision and note writes include OpenClaw idempotency/source-run markers in note content and try to reuse a matching recent note before creating another one.
 - Write-side endpoints return a config error when KV is missing instead of pretending idempotency still exists.
 - Resume responses expose attachment metadata and direct Zoho download URLs when Zoho returns attachment ids. Downloading those URLs still requires a valid Zoho OAuth token.
-- Title lookup uses the Recruit search API. Candidate detail responses with attachments and the resume endpoint also require `ZohoRecruit.modules.attachments.READ`; note workflows are safest with `ZohoRecruit.modules.notes.ALL`. After changing scopes, reconnect OAuth before retrying.
+- Title lookup uses the Recruit search API. The applicants fallback also uses exact candidate search to recover internal `candidateId` values from application contact data, so `ZohoRecruit.search.READ` is required for end-to-end applicant enrichment. Candidate detail responses with attachments and the resume endpoint also require `ZohoRecruit.modules.attachments.READ`; note workflows are safest with `ZohoRecruit.modules.notes.ALL`. After changing scopes, reconnect OAuth before retrying.
 - Zoho field names vary across tenants. The normalized payloads prefer standard Recruit fields and let operators map custom fields through `ZOHO_RECRUIT_DECISION_FIELD_MAP` rather than baking tenant assumptions into the routes.
 - Notes APIs assume the Recruit `Notes` module is available for the target record type. If your tenant does not expose notes for `Applications`, use mapped fields and/or candidate notes instead.
 
@@ -146,6 +147,7 @@ If KV is not configured, the OAuth callback returns `manualEnv.ZOHO_REFRESH_TOKE
 ## Response shape highlights
 
 - Stable resource identifiers (`applicationId`, `candidateId`, `jobOpeningId` where available)
+- Applicant fallback metadata (`candidateResolution`) when the bridge has to recover candidate ids from `Applications`
 - `previousState`, `currentState`, and `stateChange`
 - `created.noteIds` / `created.reviewIds`
 - Normalized `decision` summary and idempotency metadata

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,7 @@ For write-side endpoints, also connect Vercel KV / Upstash and ensure these are 
 - `GET /api/refresh` — refreshes access token from refresh token (protected)
 - `GET /api/recruit/ping` — validates Recruit API reachability (protected)
 - `GET /api/recruit/jobs` — lists job openings or finds one by `id` / exact `title` (protected)
-- `GET /api/recruit/jobs/:jobId/applicants` — lists associated applicants/candidates for a job opening (protected)
+- `GET /api/recruit/jobs/:jobId/applicants` — lists associated applicants/candidates for a job opening (protected). When Zoho rejects direct applicant relations, the bridge falls back to `Applications` and recovers `candidateId` from exact email/mobile/phone candidate matches when possible.
 - `GET /api/recruit/candidates/:candidateId` — returns normalized candidate detail and optional application/job context (protected)
 - `GET /api/recruit/candidates/:candidateId/resume` — returns attachment metadata and resume-oriented download URLs (protected)
 - `POST /api/recruit/applications/:applicationId/decision` — updates application state and writes decision notes (protected)
@@ -77,9 +77,11 @@ Use this callback URL in Zoho API Console:
 ## Workflow notes
 
 - Job title lookups use the Recruit search API, so `ZohoRecruit.search.READ` must be in `ZOHO_SCOPE`.
+- The applicants fallback also uses exact candidate search to recover internal `candidateId` values from application contact data, so `ZohoRecruit.search.READ` is part of the read-side contract, not just title lookup.
 - Attachment-backed candidate/resume flows require `ZohoRecruit.modules.attachments.READ`.
 - Write-side note workflows are safest with `ZohoRecruit.modules.notes.ALL` and require KV-backed idempotency storage.
 - Candidate detail responses include a normalized `reviewPayload` for scoring/rubric workflows.
+- Applicants responses may include `candidateResolution` metadata when the bridge had to recover or could not recover a `candidateId` during `Applications` fallback.
 - Resume endpoint responses merge candidate attachments and optional application attachments when `applicationId` is provided.
 - Zoho attachment `downloadUrl` values require Zoho OAuth authorization when fetched directly.
 - Decision writes are idempotent when callers provide `idempotencyKey` or `sourceRunId`; the same key with a different payload is rejected.

--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -323,17 +323,27 @@ export function normalizeApplicantRecord(record, { job = null } = {}) {
   );
   const applicationId = applicationLookup?.id ?? firstDefined(record?.id, record?.ID, record?.Application_ID, record?.Application_Id, null) ?? null;
   const candidate = normalizeCandidateRecord(record, { attachments: [], job });
-  const candidateId = candidateLookup?.id ?? null;
+  const candidateId = firstDefined(record?.candidateResolution?.candidateId, candidateLookup?.id, null) ?? null;
+  const candidateResolution = record?.candidateResolution || (candidateId
+    ? {
+        status: "provided",
+        source: "record_lookup",
+        matchedBy: null,
+        candidateId
+      }
+    : null);
 
   return {
     ...candidate,
     candidateId,
     applicationId,
+    candidateResolution,
     reviewPayload: {
       ...candidate.reviewPayload,
       candidateId,
       applicationId,
-      jobId: job?.id || candidate.jobOpening?.id || null
+      jobId: job?.id || candidate.jobOpening?.id || null,
+      candidateResolution
     }
   };
 }

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -77,7 +77,7 @@ function extractCandidateLookupId(record) {
     if (id) return String(id);
   }
 
-  const candidateId = firstDefined(record?.Candidate_Id, record?.Candidate_ID);
+  const candidateId = firstDefined(record?.Candidate_Id);
   return candidateId ? String(candidateId) : null;
 }
 

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -8,7 +8,9 @@ export const RECRUIT_MODULES = {
 };
 
 const SEARCH_FIELDS = {
-  jobTitle: ["Posting_Title", "Potential_Name"]
+  jobTitle: ["Posting_Title", "Potential_Name"],
+  candidateEmail: ["Email", "Personal_Email"],
+  candidatePhone: ["Mobile", "Phone"]
 };
 
 const AUTH_ERROR_CODES = new Set([
@@ -39,6 +41,207 @@ export function clampPositiveInt(value, fallback, { min = 1, max = 200 } = {}) {
   const parsed = Number.parseInt(String(value ?? ""), 10);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(min, Math.min(max, parsed));
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== "");
+}
+
+function normalizeEmail(value) {
+  const text = String(value || "").trim().toLowerCase();
+  return text || null;
+}
+
+function normalizePhone(value) {
+  const text = String(value || "").trim();
+  if (!text) return null;
+
+  const digits = text.replace(/[^\d]/g, "");
+  if (digits.length < 10) return null;
+  if (text.startsWith("+")) return `+${digits}`;
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  return `+${digits}`;
+}
+
+function extractCandidateLookupId(record) {
+  const candidate = record?.Candidate;
+  if (candidate && typeof candidate === "object") {
+    const id = firstDefined(candidate.id, candidate.ID, candidate.value);
+    if (id) return String(id);
+  }
+
+  const candidateName = record?.Candidate_Name;
+  if (candidateName && typeof candidateName === "object") {
+    const id = firstDefined(candidateName.id, candidateName.ID, candidateName.value);
+    if (id) return String(id);
+  }
+
+  const candidateId = firstDefined(record?.Candidate_Id, record?.Candidate_ID);
+  return candidateId ? String(candidateId) : null;
+}
+
+function buildCandidateSearchAttempts(record) {
+  const email = normalizeEmail(firstDefined(record?.Email, record?.Personal_Email, null));
+  const mobile = normalizePhone(firstDefined(record?.Mobile, null));
+  const phone = normalizePhone(firstDefined(record?.Phone, null));
+  const attempts = [];
+
+  if (email) {
+    attempts.push({
+      field: "Email",
+      value: email,
+      normalizedValue: email,
+      matchedBy: "email",
+      cacheKey: `email:${email}`
+    });
+  }
+
+  for (const [field, matchedBy, value] of [
+    ["Mobile", "mobile", mobile],
+    ["Phone", "phone", phone]
+  ]) {
+    if (!value) continue;
+    const cacheKey = `phone:${value}`;
+    if (attempts.some((attempt) => attempt.cacheKey === cacheKey)) continue;
+    attempts.push({
+      field,
+      value,
+      normalizedValue: value,
+      matchedBy,
+      cacheKey
+    });
+  }
+
+  return attempts;
+}
+
+function exactCandidateMatches(record, attempt) {
+  if (attempt.matchedBy === "email") {
+    return SEARCH_FIELDS.candidateEmail.some((field) => normalizeEmail(record?.[field]) === attempt.normalizedValue);
+  }
+
+  return SEARCH_FIELDS.candidatePhone.some((field) => normalizePhone(record?.[field]) === attempt.normalizedValue);
+}
+
+async function searchCandidatesByExactValue(attempt) {
+  try {
+    const result = await recruitRequest(`/recruit/v2/${RECRUIT_MODULES.candidates}/search`, {
+      query: {
+        criteria: `(${attempt.field}:equals:${escapeRecruitCriteriaValue(attempt.value)})`
+      }
+    });
+
+    const records = Array.isArray(result.payload?.data) ? result.payload.data : [];
+    return records.filter((record) => exactCandidateMatches(record, attempt));
+  } catch (error) {
+    const canTreatAsNoMatch = error?.type === "not_found" || error?.code === "INVALID_DATA" || error?.code === "INVALID_QUERY";
+    if (canTreatAsNoMatch) return [];
+    throw error;
+  }
+}
+
+async function resolveApplicationCandidate(record, cache) {
+  const providedCandidateId = extractCandidateLookupId(record);
+  if (providedCandidateId) {
+    return {
+      candidateId: providedCandidateId,
+      candidateResolution: {
+        status: "provided",
+        source: "application_lookup",
+        matchedBy: null,
+        candidateId: providedCandidateId
+      }
+    };
+  }
+
+  const attempts = buildCandidateSearchAttempts(record);
+  if (attempts.length === 0) {
+    return {
+      candidateId: null,
+      candidateResolution: {
+        status: "unresolved",
+        source: "candidate_search",
+        matchedBy: null,
+        reason: "missing_exact_contact",
+        candidateId: null
+      }
+    };
+  }
+
+  let sawAmbiguousMatch = false;
+  for (const attempt of attempts) {
+    let cached = cache.get(attempt.cacheKey);
+    if (!cached) {
+      const matches = await searchCandidatesByExactValue(attempt);
+      if (matches.length === 1) {
+        const candidateId = firstDefined(matches[0]?.id, matches[0]?.ID, null);
+        cached = {
+          candidateId: candidateId ? String(candidateId) : null,
+          candidateResolution: {
+            status: candidateId ? "resolved" : "unresolved",
+            source: "candidate_search",
+            matchedBy: attempt.matchedBy,
+            reason: candidateId ? null : "missing_candidate_id_on_match",
+            candidateId: candidateId ? String(candidateId) : null
+          }
+        };
+      } else if (matches.length > 1) {
+        cached = {
+          candidateId: null,
+          candidateResolution: {
+            status: "unresolved",
+            source: "candidate_search",
+            matchedBy: attempt.matchedBy,
+            reason: "ambiguous_exact_match",
+            candidateId: null
+          }
+        };
+      } else {
+        cached = {
+          candidateId: null,
+          candidateResolution: {
+            status: "unresolved",
+            source: "candidate_search",
+            matchedBy: attempt.matchedBy,
+            reason: "no_exact_match",
+            candidateId: null
+          }
+        };
+      }
+      cache.set(attempt.cacheKey, cached);
+    }
+
+    if (cached.candidateId) return cached;
+    if (cached.candidateResolution?.reason === "ambiguous_exact_match") sawAmbiguousMatch = true;
+  }
+
+  return {
+    candidateId: null,
+    candidateResolution: {
+      status: "unresolved",
+      source: "candidate_search",
+      matchedBy: null,
+      reason: sawAmbiguousMatch ? "ambiguous_exact_match" : "no_exact_match",
+      candidateId: null
+    }
+  };
+}
+
+async function resolveFallbackApplicationCandidates(records) {
+  const cache = new Map();
+  const resolved = [];
+
+  for (const record of records) {
+    const { candidateId, candidateResolution } = await resolveApplicationCandidate(record, cache);
+    resolved.push({
+      ...record,
+      ...(candidateId ? { Candidate_Id: candidateId } : {}),
+      candidateResolution
+    });
+  }
+
+  return resolved;
 }
 
 function escapeRecruitCriteriaValue(value) {
@@ -423,7 +626,7 @@ async function listJobApplicantsFromApplications(jobId, query = {}) {
   }
 
   const startIndex = (page - 1) * perPage;
-  const data = matches.slice(startIndex, startIndex + perPage);
+  const data = await resolveFallbackApplicationCandidates(matches.slice(startIndex, startIndex + perPage));
   const hasAdditionalMatches = matches.length > startIndex + data.length;
 
   return {

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -59,9 +59,8 @@ function normalizePhone(value) {
   const digits = text.replace(/[^\d]/g, "");
   if (digits.length < 10) return null;
   if (text.startsWith("+")) return `+${digits}`;
-  if (digits.length === 10) return `+1${digits}`;
   if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
-  return `+${digits}`;
+  return digits;
 }
 
 function extractCandidateLookupId(record) {
@@ -133,10 +132,27 @@ async function searchCandidatesByExactValue(attempt) {
     });
 
     const records = Array.isArray(result.payload?.data) ? result.payload.data : [];
-    return records.filter((record) => exactCandidateMatches(record, attempt));
+    return {
+      matches: records.filter((record) => exactCandidateMatches(record, attempt)),
+      error: null
+    };
   } catch (error) {
     const canTreatAsNoMatch = error?.type === "not_found" || error?.code === "INVALID_DATA" || error?.code === "INVALID_QUERY";
-    if (canTreatAsNoMatch) return [];
+    if (canTreatAsNoMatch) {
+      return {
+        matches: [],
+        error: null
+      };
+    }
+
+    const canTreatAsUnresolved = error?.type === "scope" || error?.type === "recruit_api" || error?.type === "missing_module";
+    if (canTreatAsUnresolved) {
+      return {
+        matches: [],
+        error
+      };
+    }
+
     throw error;
   }
 }
@@ -170,10 +186,11 @@ async function resolveApplicationCandidate(record, cache) {
   }
 
   let sawAmbiguousMatch = false;
+  let sawSearchFailure = false;
   for (const attempt of attempts) {
     let cached = cache.get(attempt.cacheKey);
     if (!cached) {
-      const matches = await searchCandidatesByExactValue(attempt);
+      const { matches, error } = await searchCandidatesByExactValue(attempt);
       if (matches.length === 1) {
         const candidateId = firstDefined(matches[0]?.id, matches[0]?.ID, null);
         cached = {
@@ -197,6 +214,17 @@ async function resolveApplicationCandidate(record, cache) {
             candidateId: null
           }
         };
+      } else if (error) {
+        cached = {
+          candidateId: null,
+          candidateResolution: {
+            status: "unresolved",
+            source: "candidate_search",
+            matchedBy: attempt.matchedBy,
+            reason: "candidate_search_failed",
+            candidateId: null
+          }
+        };
       } else {
         cached = {
           candidateId: null,
@@ -214,6 +242,7 @@ async function resolveApplicationCandidate(record, cache) {
 
     if (cached.candidateId) return cached;
     if (cached.candidateResolution?.reason === "ambiguous_exact_match") sawAmbiguousMatch = true;
+    if (cached.candidateResolution?.reason === "candidate_search_failed") sawSearchFailure = true;
   }
 
   return {
@@ -222,7 +251,7 @@ async function resolveApplicationCandidate(record, cache) {
       status: "unresolved",
       source: "candidate_search",
       matchedBy: null,
-      reason: sawAmbiguousMatch ? "ambiguous_exact_match" : "no_exact_match",
+      reason: sawAmbiguousMatch ? "ambiguous_exact_match" : (sawSearchFailure ? "candidate_search_failed" : "no_exact_match"),
       candidateId: null
     }
   };

--- a/api/recruit/_shared.js
+++ b/api/recruit/_shared.js
@@ -102,7 +102,7 @@ function buildCandidateSearchAttempts(record) {
     ["Phone", "phone", phone]
   ]) {
     if (!value) continue;
-    const cacheKey = `phone:${value}`;
+    const cacheKey = `${matchedBy}:${value}`;
     if (attempts.some((attempt) => attempt.cacheKey === cacheKey)) continue;
     attempts.push({
       field,

--- a/docs/plans/2026-04-22-001-fix-application-fallback-candidate-resolution-plan.md
+++ b/docs/plans/2026-04-22-001-fix-application-fallback-candidate-resolution-plan.md
@@ -1,0 +1,286 @@
+---
+title: fix: Restore candidate resolution in applications fallback
+type: fix
+status: active
+date: 2026-04-22
+---
+
+# fix: Restore candidate resolution in applications fallback
+
+## Overview
+
+The `JobOpenings/:id/Candidates` and `JobOpenings/:id/associate` relations are not reliable in this Zoho Recruit account, so the bridge already falls back to listing `Applications`. That fallback currently returns enrichment-dead applicant payloads because `candidateId` stays null, which prevents downstream candidate detail, resume download, and resume parsing flows from running. This plan restores a usable read contract for fallback applicants without changing write-side behavior.
+
+## Problem Frame
+
+Live smoke testing showed the resume parser itself works when given a real candidate/application pair, but the normal triage path cannot reach it from `/api/recruit/jobs/:jobId/applicants`.
+
+The full causal chain is:
+
+- `api/recruit/_shared.js` falls back from `JobOpenings/:id/Candidates` and `JobOpenings/:id/associate` to `/recruit/v2/Applications`.
+- The fallback fetch requests raw application rows only, with no candidate-resolution step.
+- In this live Zoho tenant, those application rows contain job/contact fields but do not carry a usable `Candidate`, `Candidate_Name`, or `Candidate_Id` lookup for the returned records.
+- `api/recruit/_normalize.js` only fills `candidateId` from those lookup fields, so normalized fallback applicants leave `candidateId: null`.
+- Downstream consumers treat `candidateId` as the bridge from applicant listing to candidate detail. In particular, `zoho-attio-recruit-triage` exits enrichment early with `missing_candidate_id`, so it never reaches `GET /api/recruit/candidates/:candidateId`, `/resume-content`, or local resume parsing.
+
+This is a contract bug in the bridge fallback path, not a parser bug.
+
+## Requirements Trace
+
+- R1. `GET /api/recruit/jobs/:jobId/applicants` must remain usable when both direct applicant relations fail and the bridge falls back to `Applications`.
+- R2. Fallback applicants must include a usable internal `candidateId` whenever the bridge can resolve a unique candidate match from exact application contact data.
+- R3. Ambiguous or unresolvable fallback records must stay explicit and safe rather than guessing a candidate link.
+- R4. Regression coverage must prove that fallback applicants can reach downstream resume enrichment again.
+- R5. Public docs must describe the fallback contract and its dependency on exact contact data plus `ZohoRecruit.search.READ`.
+
+## Scope Boundaries
+
+- No Attio write-path changes.
+- No changes to Zoho Recruit write-side endpoints.
+- No fuzzy candidate matching by name alone.
+- No tenant-specific field customization assumptions in the bridge contract.
+
+### Deferred to Separate Tasks
+
+- Downstream execution work in `zoho-attio-recruit-triage` if the team wants extra consumer-side smoke automation after the bridge contract is fixed.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `api/recruit/_shared.js` owns Recruit fetches, retries, fallback decisions, and search helpers.
+- `api/recruit/_normalize.js` defines the applicant contract consumed by downstream skills.
+- `api/recruit/jobs/[jobId]/applicants.js` is the public read endpoint that assembles the normalized payload.
+- `tests/job-applicants.test.js` already covers relation fallback, applicant normalization, and resume-content regressions.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/restore-zoho-recruit-bridge-readiness-on-vercel-and-add-applicants-fallback.md` documents why the account needs the `Applications` fallback at all, but it currently overstates fallback readiness because it does not cover `candidateId` loss.
+
+### External References
+
+- Zoho Recruit Get Records API documents optional `fields` selection for list retrieval and shows that lookup values are module-field dependent: https://www.zoho.com/recruit/developer-guide/apiv2/get-records.html
+- Zoho Recruit Applications docs state every candidate has an associated application, but that does not guarantee the list API returns a candidate lookup in this tenant’s current layout/response shape: https://help.zoho.com/portal/en/kb/recruit/talent-management/applications/articles/applications-in-zoho-recruit
+- Zoho Recruit Application customization docs show candidate/job fields in Applications are layout-driven/inherited, which is a strong signal that the bridge cannot safely assume those lookup fields will always be present in API list responses: https://help.zoho.com/portal/en/kb/recruit/talent-management/applications/articles/customizing-applications-in-zoho-recruit
+
+## Key Technical Decisions
+
+- Resolve fallback `candidateId` inside the bridge, not in downstream triage code.
+  Rationale: the broken contract originates in the bridge endpoint, and downstream consumers already correctly expect `candidateId` to be part of applicant identity.
+
+- Use exact candidate search by application contact data (`Email` first, then normalized `Mobile`/`Phone`) only for fallback rows that lack a candidate lookup.
+  Rationale: live probing showed exact email and exact mobile searches both return the correct candidate in this tenant, while name-only lookup would be unsafe.
+
+- Require a unique exact match before populating `candidateId`.
+  Rationale: ambiguous candidate search results should not silently bind an application to the wrong candidate.
+
+- Resolve only the paged fallback rows returned to the client, not every scanned application row used for pagination.
+  Rationale: this keeps API volume bounded and avoids unnecessary search traffic while preserving current pagination behavior.
+
+- Preserve unresolved records with explicit null `candidateId` and attach machine-readable resolution metadata.
+  Rationale: consumers need to distinguish “unresolved safely” from “field omitted accidentally”.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the plan rely on `Applications?fields=Candidate...`?
+  Resolution: no. Live probes on this tenant showed application records still lacked a usable candidate lookup, and the Applications layout is tenant-dependent.
+
+- Is exact candidate search viable with current bridge scope?
+  Resolution: yes. Live probes succeeded with exact `Email` and `Mobile` searches, and the deployed bridge already includes `ZohoRecruit.search.READ`.
+
+### Deferred to Implementation
+
+- Exact naming for the candidate-resolution metadata fields on the applicant payload.
+  Why deferred: this is contract-shape detail best settled while editing the existing normalization code.
+
+- Whether to cache candidate search results only within a request or promote them to a shared helper with broader reuse.
+  Why deferred: the correct extraction boundary depends on the final shape of the helper during implementation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  A[GET /api/recruit/jobs/:jobId/applicants] --> B{Direct relation works?}
+  B -->|yes| C[Normalize applicant rows]
+  B -->|no| D[List Applications for job]
+  D --> E[Take requested page slice]
+  E --> F{Candidate lookup present?}
+  F -->|yes| C
+  F -->|no| G[Search Candidates by exact Email]
+  G -->|unique match| H[Attach candidateId]
+  G -->|none/ambiguous| I[Search Candidates by exact Mobile or Phone]
+  I -->|unique match| H
+  I -->|none/ambiguous| J[Keep candidateId null + resolution status]
+  H --> C
+  J --> C
+  C --> K[Downstream enrichZohoApplicant can call candidate detail + resume-content when candidateId exists]
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add exact-contact candidate resolution for fallback applicants**
+
+**Goal:** Resolve internal `candidateId` values for paged fallback application rows using safe, exact candidate search.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `api/recruit/_shared.js`
+- Test: `tests/job-applicants.test.js`
+
+**Approach:**
+- Add a Recruit search helper for candidate lookup that uses existing request/error normalization.
+- Resolve fallback rows only after pagination is determined, so search cost scales with returned rows rather than scan volume.
+- Search exact email first when present, then exact mobile/phone when present.
+- Accept only a unique exact candidate result; leave unresolved rows unchanged if the search returns zero or multiple candidates.
+- Cache repeated exact-contact searches within the request so duplicate email/phone values do not cause duplicate API calls.
+
+**Patterns to follow:**
+- `api/recruit/_shared.js` `searchJobOpeningsByTitle`
+- `api/recruit/_shared.js` request retry/error classification flow
+
+**Test scenarios:**
+- Happy path: fallback application row with exact email and no lookup fields resolves to the matching internal candidate id.
+- Happy path: fallback application row with no email but exact mobile resolves to the matching internal candidate id.
+- Edge case: two fallback rows sharing the same exact email reuse the cached search result and both receive the same candidate id.
+- Error path: candidate search returns no results and the fallback row stays unresolved without failing the entire applicants response.
+- Error path: candidate search returns multiple exact matches and the fallback row stays unresolved rather than guessing.
+- Integration: direct relation failures followed by `Applications` fallback still return paged applicants successfully while enriching candidate ids for the returned page slice.
+
+**Verification:**
+- The fallback code path still returns applicant lists when direct relations fail.
+- Returned fallback applicants include internal `candidateId` when Zoho candidate search finds a unique exact match.
+- Search amplification remains bounded to returned rows plus cache misses.
+
+- [x] **Unit 2: Expose resolution state in the normalized applicant contract**
+
+**Goal:** Make fallback candidate-resolution outcomes visible in the normalized applicant payload so downstream consumers and operators can distinguish resolved, unresolved, and ambiguous cases.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `api/recruit/_normalize.js`
+- Modify: `api/recruit/jobs/[jobId]/applicants.js`
+- Test: `tests/job-applicants.test.js`
+
+**Approach:**
+- Extend applicant normalization so candidate resolution can carry both the resolved `candidateId` and a small status/source descriptor.
+- Preserve existing `applicationId` behavior and current top-level applicant shape wherever possible to avoid unnecessary consumer churn.
+- Thread the resolution metadata into `reviewPayload` so downstream consumers do not have to infer whether `candidateId: null` means “truly absent” or “lookup not attempted”.
+
+**Patterns to follow:**
+- `api/recruit/_normalize.js` `normalizeApplicantRecord`
+- Existing `reviewPayload` enrichment conventions in candidate/application normalization
+
+**Test scenarios:**
+- Happy path: resolved fallback applicant exposes both `candidateId` and a resolution source/status in normalized output.
+- Edge case: fallback applicant with native `Candidate` lookup keeps that id and is not overwritten by search-derived metadata.
+- Error path: unresolved fallback applicant keeps `candidateId: null` and exposes a non-success resolution status.
+- Integration: `/api/recruit/jobs/:jobId/applicants` response remains backward-compatible for existing fields while adding the new resolution metadata.
+
+**Verification:**
+- Consumers can tell whether a fallback row is ready for candidate enrichment without performing additional inference.
+- Existing fields in the applicants response remain stable for current callers.
+
+- [x] **Unit 3: Lock the bridge regression with end-to-end fallback enrichment coverage**
+
+**Goal:** Prevent a recurrence where fallback applicants look “OK” in isolation but still cannot drive candidate-detail and resume flows.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `tests/job-applicants.test.js`
+
+**Approach:**
+- Add a contract-style regression that starts with direct relation failure, exercises the `Applications` fallback, and asserts the normalized applicant output is enrichment-ready.
+- Keep this test bridge-local rather than importing triage code, so the bridge owns its own public contract.
+- Cover both the successful-resolution path and the explicit unresolved path.
+
+**Execution note:** Start from a failing bridge-level contract test that asserts fallback applicants include a usable internal `candidateId` for exact-match records.
+
+**Patterns to follow:**
+- Existing mocked fetch coverage in `tests/job-applicants.test.js`
+- Resume-content regression style added for recent bridge fixes
+
+**Test scenarios:**
+- Happy path: fallback application with exact email produces normalized applicant output that includes the internal candidate id needed for downstream candidate detail.
+- Error path: fallback application with ambiguous candidate search remains unresolved and surfaces the expected status marker.
+- Integration: the same fallback fixture that previously produced `candidateId: null` now produces an enrichment-ready applicant contract.
+
+**Verification:**
+- The regression test fails against the current bug and passes only after candidate resolution is wired through normalization.
+
+- [x] **Unit 4: Update operator docs and smoke guidance for the corrected fallback contract**
+
+**Goal:** Keep repo documentation aligned with the real fallback behavior and the new candidate-resolution dependency.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1, Unit 2, Unit 3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `docs/solutions/integration-issues/restore-zoho-recruit-bridge-readiness-on-vercel-and-add-applicants-fallback.md`
+
+**Approach:**
+- Document that `Applications` fallback now resolves `candidateId` from exact contact search when native lookups are absent.
+- Keep the scope guidance explicit: fallback enrichment depends on `ZohoRecruit.search.READ` and exact email/mobile values on the application row.
+- Update the existing solution doc so it no longer implies the March fallback was fully end-to-end ready.
+
+**Patterns to follow:**
+- Existing read-side endpoint contract documentation in `README.md`
+- Live-verification narrative style in the existing solution doc
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only unit.
+
+**Verification:**
+- Repo docs describe the actual bridge contract and smoke path operators should expect in production.
+
+## System-Wide Impact
+
+- **Interaction graph:** `jobs/[jobId]/applicants` now depends on candidate search in addition to direct relations and `Applications` listing when fallback is active.
+- **Error propagation:** candidate-resolution misses should degrade per-row, not fail the whole applicants request; true Recruit auth/scope errors should still bubble as API errors.
+- **State lifecycle risks:** no persistent state changes are introduced, but per-request caching must not leak results across requests.
+- **API surface parity:** this change strengthens the existing applicants contract rather than creating a new endpoint; downstream consumers should not need new fetch flows.
+- **Integration coverage:** bridge tests must prove fallback applicants are candidate-enrichment ready, because unit tests that only assert row counts and `info.source` are insufficient.
+- **Unchanged invariants:** `applicationId` fallback behavior, paging semantics, and direct relation success paths remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Candidate search adds extra Zoho API traffic on fallback requests | Resolve only paged rows, cache repeated exact-contact lookups within the request, and keep direct relation success paths unchanged |
+| Exact contact search may return multiple candidates | Treat non-unique matches as unresolved and surface explicit resolution status instead of guessing |
+| Some application rows may lack usable email and phone values | Preserve null `candidateId` with an explicit unresolved status so callers can skip safely |
+| Documentation drifts again from live contract behavior | Update the existing solution doc and README/SKILL in the same change as the code fix |
+
+## Documentation / Operational Notes
+
+- Re-run the live smoke in production after implementation:
+  1. `GET /api/recruit/jobs/850051000000560065/applicants`
+  2. confirm at least one fallback applicant now carries an internal `candidateId`
+  3. use that `candidateId` to verify `/api/recruit/candidates/:candidateId` and `/resume-content`
+- Keep `ZOHO_SCOPE` documentation explicit about `ZohoRecruit.search.READ`; fallback candidate resolution depends on it.
+
+## Sources & References
+
+- Related code: `api/recruit/_shared.js`
+- Related code: `api/recruit/_normalize.js`
+- Related code: `api/recruit/jobs/[jobId]/applicants.js`
+- Related tests: `tests/job-applicants.test.js`
+- Related learning: `docs/solutions/integration-issues/restore-zoho-recruit-bridge-readiness-on-vercel-and-add-applicants-fallback.md`
+- External docs: https://www.zoho.com/recruit/developer-guide/apiv2/get-records.html
+- External docs: https://help.zoho.com/portal/en/kb/recruit/talent-management/applications/articles/applications-in-zoho-recruit
+- External docs: https://help.zoho.com/portal/en/kb/recruit/talent-management/applications/articles/customizing-applications-in-zoho-recruit

--- a/docs/solutions/integration-issues/restore-zoho-recruit-bridge-readiness-on-vercel-and-add-applicants-fallback.md
+++ b/docs/solutions/integration-issues/restore-zoho-recruit-bridge-readiness-on-vercel-and-add-applicants-fallback.md
@@ -136,6 +136,20 @@ In [api/recruit/_normalize.js](/home/art/projects/skills/work/zoho-recruit-openc
 
 - `normalizeApplicantRecord()` now falls back to the internal application record id (`record.id`) instead of only external `Application_ID`
 
+## Follow-up gap discovered on 2026-04-22
+
+The March fallback restored applicant listing availability, but it did not fully restore applicant-to-candidate linkage.
+
+- Live `Applications` fallback rows in this tenant can still omit usable `Candidate` / `Candidate_Name` / `Candidate_Id` lookups.
+- That means `/api/recruit/jobs/:jobId/applicants` can return rows with `candidateId: null` even though the matching candidate exists.
+- Downstream consumers that need `GET /api/recruit/candidates/:candidateId` or `/resume-content` will stop at applicant listing unless the bridge recovers the internal candidate id from exact application contact data.
+
+The corrected bridge behavior is:
+
+- keep the `Applications` fallback for listing availability
+- recover `candidateId` from exact candidate search on application `Email`, then `Mobile` / `Phone`, when native lookups are absent
+- leave ambiguous or unresolvable rows explicit via `candidateResolution` metadata instead of guessing
+
 # Live Verification
 
 After both PRs were merged and production was redeployed, the following were verified live in production:

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -128,6 +128,29 @@ test("normalizeApplicantRecord preserves the related candidate record id separat
   assert.equal(applicant.reviewPayload.candidateId, "850051000000577777");
 });
 
+test("normalizeApplicantRecord preserves fallback candidate resolution metadata", async () => {
+  const { normalizeApplicantRecord } = await importFresh("../api/recruit/_normalize.js");
+  const applicant = normalizeApplicantRecord({
+    id: "850051000000588062",
+    Application_ID: "ZR_8_APP",
+    Full_Name: "Jacoby Curry",
+    Email: "coby@example.com",
+    candidateResolution: {
+      status: "resolved",
+      source: "candidate_search",
+      matchedBy: "email",
+      reason: null,
+      candidateId: "850051000000577777"
+    }
+  });
+
+  assert.equal(applicant.applicationId, "850051000000588062");
+  assert.equal(applicant.candidateId, "850051000000577777");
+  assert.equal(applicant.candidateResolution?.status, "resolved");
+  assert.equal(applicant.candidateResolution?.matchedBy, "email");
+  assert.equal(applicant.reviewPayload.candidateResolution?.candidateId, "850051000000577777");
+});
+
 test("listJobApplicants falls back to Applications when Zoho rejects job candidate relations", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",
@@ -183,6 +206,13 @@ test("listJobApplicants falls back to Applications when Zoho rejects job candida
         });
       }
 
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        return jsonResponse({
+          data: [],
+          info: { more_records: false }
+        });
+      }
+
       throw new Error(`Unexpected fetch: ${value}`);
     }, async () => {
       const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
@@ -194,9 +224,278 @@ test("listJobApplicants falls back to Applications when Zoho rejects job candida
 
       assert.equal(result.payload.data.length, 1);
       assert.equal(result.payload.data[0].id, "850051000000588062");
+      assert.equal(result.payload.data[0].Candidate_Id, undefined);
+      assert.equal(result.payload.data[0].candidateResolution?.status, "unresolved");
       assert.equal(result.payload.info.source, "applications_fallback");
       assert.equal(calls.some((url) => url.includes("/Candidates")), true);
       assert.equal(calls.some((url) => url.includes("/associate")), true);
+    });
+  });
+});
+
+test("listJobApplicants fallback resolves unique candidate ids from exact email and caches duplicate lookups", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    const candidateSearchCalls = [];
+
+    await withMockFetch(async (url) => {
+      const value = String(url);
+      const parsed = new URL(value);
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078",
+              Application_Status: "Applied"
+            },
+            {
+              id: "850051000000588064",
+              Application_ID: "ZR_8_APP_2",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry Duplicate",
+              Email: "coby@example.com",
+              Mobile: "+16363780078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 2,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        candidateSearchCalls.push(parsed.searchParams.get("criteria"));
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000577777",
+              Candidate_ID: "ZR_8_CAND",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078"
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 2);
+      assert.equal(result.payload.data[0].Candidate_Id, "850051000000577777");
+      assert.equal(result.payload.data[0].candidateResolution?.status, "resolved");
+      assert.equal(result.payload.data[0].candidateResolution?.matchedBy, "email");
+      assert.equal(result.payload.data[1].Candidate_Id, "850051000000577777");
+      assert.equal(result.payload.data[1].candidateResolution?.status, "resolved");
+      assert.deepEqual(candidateSearchCalls, ["(Email:equals:coby@example.com)"]);
+    });
+  });
+});
+
+test("listJobApplicants fallback keeps ambiguous candidate searches unresolved", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000577777",
+              Candidate_ID: "ZR_8_CAND",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078"
+            },
+            {
+              id: "850051000000577778",
+              Candidate_ID: "ZR_9_CAND",
+              Full_Name: "Jacoby Curry Clone",
+              Email: "coby@example.com",
+              Mobile: "+16363780078"
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 1);
+      assert.equal(result.payload.data[0].Candidate_Id, undefined);
+      assert.equal(result.payload.data[0].candidateResolution?.status, "unresolved");
+      assert.equal(result.payload.data[0].candidateResolution?.reason, "ambiguous_exact_match");
+    });
+  });
+});
+
+test("job applicants handler returns fallback applicants with resolved candidate ids", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.endsWith("/recruit/v2/JobOpenings/850051000000560065")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000560065",
+              Posting_Title: "Founding Sales Rep (Full-Cycle) (Remote, US)",
+              Job_Opening_Status: "In-progress"
+            }
+          ]
+        });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000577777",
+              Candidate_ID: "ZR_8_CAND",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078"
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { default: handler } = await importFresh("../api/recruit/jobs/[jobId]/applicants.js");
+      const req = {
+        query: { jobId: "850051000000560065", page: "1", perPage: "50" },
+        headers: {}
+      };
+      const res = createResponseRecorder();
+
+      await handler(req, res);
+
+      assert.equal(res.code, 200);
+      assert.equal(res.body.ok, true);
+      assert.equal(res.body.info.source, "applications_fallback");
+      assert.equal(res.body.applicants[0].candidateId, "850051000000577777");
+      assert.equal(res.body.applicants[0].candidateResolution.status, "resolved");
+      assert.equal(res.body.reviewPayloads[0].candidateId, "850051000000577777");
     });
   });
 });

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -408,6 +408,100 @@ test("listJobApplicants fallback does not treat Candidate_ID candidate numbers a
   });
 });
 
+test("listJobApplicants fallback retries exact phone lookup when mobile and phone share digits", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    const candidateSearchCalls = [];
+
+    await withMockFetch(async (url) => {
+      const value = String(url);
+      const parsed = new URL(value);
+      const criteria = parsed.searchParams.get("criteria");
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Mobile: "+16363780078",
+              Phone: "+1 (636) 378-0078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        candidateSearchCalls.push(criteria);
+
+        if (criteria === "(Mobile:equals:+16363780078)") {
+          return jsonResponse({
+            data: [],
+            info: { more_records: false }
+          });
+        }
+
+        if (criteria === "(Phone:equals:+16363780078)") {
+          return jsonResponse({
+            data: [
+              {
+                id: "850051000000577777",
+                Candidate_ID: "ZR_8_CAND",
+                Full_Name: "Jacoby Curry",
+                Phone: "+16363780078"
+              }
+            ],
+            info: { more_records: false }
+          });
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 1);
+      assert.equal(result.payload.data[0].Candidate_Id, "850051000000577777");
+      assert.equal(result.payload.data[0].candidateResolution?.status, "resolved");
+      assert.equal(result.payload.data[0].candidateResolution?.matchedBy, "phone");
+      assert.deepEqual(candidateSearchCalls, [
+        "(Mobile:equals:+16363780078)",
+        "(Phone:equals:+16363780078)"
+      ]);
+    });
+  });
+});
+
 test("listJobApplicants fallback keeps ambiguous candidate searches unresolved", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -502,6 +502,91 @@ test("listJobApplicants fallback retries exact phone lookup when mobile and phon
   });
 });
 
+test("listJobApplicants fallback preserves 10-digit local phones without prepending +1", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    const candidateSearchCalls = [];
+
+    await withMockFetch(async (url) => {
+      const value = String(url);
+      const parsed = new URL(value);
+      const criteria = parsed.searchParams.get("criteria");
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Mobile: "6363780078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        candidateSearchCalls.push(criteria);
+
+        if (criteria === "(Mobile:equals:6363780078)") {
+          return jsonResponse({
+            data: [
+              {
+                id: "850051000000577777",
+                Candidate_ID: "ZR_8_CAND",
+                Full_Name: "Jacoby Curry",
+                Mobile: "6363780078"
+              }
+            ],
+            info: { more_records: false }
+          });
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 1);
+      assert.equal(result.payload.data[0].Candidate_Id, "850051000000577777");
+      assert.equal(result.payload.data[0].candidateResolution?.status, "resolved");
+      assert.equal(result.payload.data[0].candidateResolution?.matchedBy, "mobile");
+      assert.deepEqual(candidateSearchCalls, [
+        "(Mobile:equals:6363780078)"
+      ]);
+    });
+  });
+});
+
 test("listJobApplicants fallback keeps ambiguous candidate searches unresolved", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",
@@ -581,6 +666,74 @@ test("listJobApplicants fallback keeps ambiguous candidate searches unresolved",
       assert.equal(result.payload.data[0].Candidate_Id, undefined);
       assert.equal(result.payload.data[0].candidateResolution?.status, "unresolved");
       assert.equal(result.payload.data[0].candidateResolution?.reason, "ambiguous_exact_match");
+    });
+  });
+});
+
+test("listJobApplicants fallback keeps applicants when candidate search fails", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    await withMockFetch(async (url) => {
+      const value = String(url);
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        return jsonResponse({
+          code: "NO_PERMISSION",
+          message: "the user does not have permission to access this resource"
+        }, { ok: false, status: 403 });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 1);
+      assert.equal(result.payload.data[0].Candidate_Id, undefined);
+      assert.equal(result.payload.data[0].candidateResolution?.status, "unresolved");
+      assert.equal(result.payload.data[0].candidateResolution?.reason, "candidate_search_failed");
+      assert.equal(result.payload.info.source, "applications_fallback");
     });
   });
 });

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -325,6 +325,89 @@ test("listJobApplicants fallback resolves unique candidate ids from exact email 
   });
 });
 
+test("listJobApplicants fallback does not treat Candidate_ID candidate numbers as internal record ids", async () => {
+  await withEnv({
+    ZOHO_ACCESS_TOKEN: "access-demo",
+    ZOHO_ACCESS_TOKEN_EXPIRES_AT: "9999999999999"
+  }, async () => {
+    const candidateSearchCalls = [];
+
+    await withMockFetch(async (url) => {
+      const value = String(url);
+      const parsed = new URL(value);
+
+      if (value.includes("/JobOpenings/850051000000560065/Candidates")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/JobOpenings/850051000000560065/associate")) {
+        return jsonResponse({
+          code: "INVALID_DATA",
+          message: "the relation name given seems to be invalid"
+        }, { ok: false, status: 400 });
+      }
+
+      if (value.includes("/recruit/v2/Applications?page=1&per_page=200")) {
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000588062",
+              Application_ID: "ZR_8_APP",
+              Candidate_ID: "ZR_8_CAND",
+              $Job_Opening_Id: "850051000000560065",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078",
+              Application_Status: "Applied"
+            }
+          ],
+          info: {
+            count: 1,
+            page: 1,
+            per_page: 200,
+            more_records: false
+          }
+        });
+      }
+
+      if (value.includes("/recruit/v2/Candidates/search")) {
+        candidateSearchCalls.push(parsed.searchParams.get("criteria"));
+        return jsonResponse({
+          data: [
+            {
+              id: "850051000000577777",
+              Candidate_ID: "ZR_8_CAND",
+              Full_Name: "Jacoby Curry",
+              Email: "coby@example.com",
+              Mobile: "+16363780078"
+            }
+          ],
+          info: { more_records: false }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${value}`);
+    }, async () => {
+      const { listJobApplicants } = await importFresh("../api/recruit/_shared.js");
+      const result = await listJobApplicants("850051000000560065", {
+        page: 1,
+        per_page: 50,
+        candidate_statuses: "Applied"
+      });
+
+      assert.equal(result.payload.data.length, 1);
+      assert.equal(result.payload.data[0].Candidate_Id, "850051000000577777");
+      assert.equal(result.payload.data[0].Candidate_ID, "ZR_8_CAND");
+      assert.equal(result.payload.data[0].candidateResolution?.status, "resolved");
+      assert.equal(result.payload.data[0].candidateResolution?.source, "candidate_search");
+      assert.deepEqual(candidateSearchCalls, ["(Email:equals:coby@example.com)"]);
+    });
+  });
+});
+
 test("listJobApplicants fallback keeps ambiguous candidate searches unresolved", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",


### PR DESCRIPTION
## What
- recover internal `candidateId` values for `Applications` fallback applicants using exact email/mobile/phone candidate search
- expose `candidateResolution` metadata so downstream consumers can distinguish provided, recovered, and unresolved applicant rows
- add bridge-level regressions for unique-match, ambiguous-match, and applicants-handler fallback behavior
- update README, SKILL, and the existing incident doc to reflect the corrected fallback contract

## Why
This Zoho Recruit tenant rejects the direct `JobOpenings/:id/Candidates` relation, so the bridge falls back to `Applications`. Those fallback rows can omit native candidate lookups, which left `candidateId` null and blocked downstream candidate detail, resume download, and resume parsing. This change restores an enrichment-ready applicants contract on the fallback path.

## Risk
- adds candidate-search traffic on fallback requests, bounded to the returned page and cached per request
- ambiguous exact matches intentionally stay unresolved rather than guessing
- no write-side behavior changes

## How Verified
- `npm test` in `zoho-recruit-openclaw-skill` (17/17 passing)
- live read-only smoke against production after deploy:
  - `/api/recruit/jobs/850051000000560065/applicants` returned `info.source: "applications_fallback"`
  - application `850051000000588062` resolved to candidate `850051000000588003` via `candidateResolution.source: "candidate_search"`
  - `/api/recruit/candidates/850051000000588003/resume-content?applicationId=850051000000588062` returned the real application PDF attachment
  - local parse of the hosted payload succeeded with `parser: "pdf"`, `textLength: 3249`, and no warnings

## Note
A separate pre-existing issue remains: Zoho returns `EXTRA_PARAM_FOUND` if `candidate_statuses` is sent to the direct relation path. This PR does not change that behavior.
