### PR TITLE
fix(recruit): preserve application lifecycle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If KV is not configured, the OAuth callback returns `manualEnv.ZOHO_REFRESH_TOKE
 - Access tokens are loaded from KV when present, otherwise refreshed from `ZOHO_REFRESH_TOKEN` and cached only in memory for the current runtime instance.
 - Recruit errors are normalized into clear JSON types such as `auth`, `scope`, `missing_module`, `not_found`, and `idempotency_conflict`.
 - Applicants fallback rows may include `candidateResolution` metadata showing whether `candidateId` came from an application lookup, exact candidate search, or remained unresolved.
+- Applicants and candidate-detail payloads preserve application lifecycle state in normalized `application` / `reviewPayload` fields, including `Application_Status` and `Hiring_Pipeline` when Zoho exposes them.
 - Decision endpoints treat `decision` as normalized audit metadata. Actual Recruit stage/status changes come from explicit `target.stage` / `target.status`, extra `fieldValues`, or `ZOHO_RECRUIT_DECISION_FIELD_MAP`; the API does not guess tenant-specific stage names.
 - Decision, note, and patch endpoints support request-level idempotency keyed by `idempotencyKey` or `sourceRunId`. Reusing the same key with a different payload returns `409 idempotency_conflict`.
 - Decision endpoints write a Recruit note by default so downstream CRM sync and audit logging have a durable human-readable trail.

--- a/SKILL.md
+++ b/SKILL.md
@@ -82,6 +82,7 @@ Use this callback URL in Zoho API Console:
 - Write-side note workflows are safest with `ZohoRecruit.modules.notes.ALL` and require KV-backed idempotency storage.
 - Candidate detail responses include a normalized `reviewPayload` for scoring/rubric workflows.
 - Applicants responses may include `candidateResolution` metadata when the bridge had to recover or could not recover a `candidateId` during `Applications` fallback.
+- Application lifecycle state such as `Application_Status` and `Hiring_Pipeline` should survive normalization so downstream triage can distinguish rejected applicants from generic candidate state.
 - Resume endpoint responses merge candidate attachments and optional application attachments when `applicationId` is provided.
 - Zoho attachment `downloadUrl` values require Zoho OAuth authorization when fetched directly.
 - Decision writes are idempotent when callers provide `idempotencyKey` or `sourceRunId`; the same key with a different payload is rejected.

--- a/api/recruit/_normalize.js
+++ b/api/recruit/_normalize.js
@@ -191,6 +191,7 @@ function buildReviewPayload(candidate, attachments, { application = null, job = 
     jobId: job?.id || candidate.jobOpening?.id || null,
     fullName: candidate.fullName,
     status: application?.status || candidate.status,
+    stage: application?.stage || null,
     rating: candidate.rating,
     source: application?.source || candidate.source,
     experienceYears: candidate.experienceYears,
@@ -214,7 +215,7 @@ export function normalizeApplicationRecord(record) {
   return {
     id: String(firstDefined(record?.id, record?.ID, "")),
     status: firstDefined(record?.Application_Status, record?.Status, record?.Candidate_Status, null),
-    stage: firstDefined(record?.Stage, record?.Pipeline_Stage, null),
+    stage: firstDefined(record?.Stage, record?.Pipeline_Stage, record?.Hiring_Pipeline, record?.Application_Stage, null),
     source: firstDefined(record?.Source, record?.Application_Source, null),
     candidate: mergeLookups(
       normalizeLookup(record?.Candidate),
@@ -311,6 +312,7 @@ export function normalizeCandidateRecord(record, { attachments = [], application
 }
 
 export function normalizeApplicantRecord(record, { job = null } = {}) {
+  const application = normalizeApplicationRecord(record);
   const applicationLookup = mergeLookups(
     normalizeLookup(record?.Application),
     normalizeLookup(record?.Application_Name, { primitive: "name" }),
@@ -322,7 +324,7 @@ export function normalizeApplicantRecord(record, { job = null } = {}) {
     normalizeLookup(record?.Candidate_Id, { primitive: "id" })
   );
   const applicationId = applicationLookup?.id ?? firstDefined(record?.id, record?.ID, record?.Application_ID, record?.Application_Id, null) ?? null;
-  const candidate = normalizeCandidateRecord(record, { attachments: [], job });
+  const candidate = normalizeCandidateRecord(record, { attachments: [], application, job });
   const candidateId = firstDefined(record?.candidateResolution?.candidateId, candidateLookup?.id, null) ?? null;
   const candidateResolution = record?.candidateResolution || (candidateId
     ? {
@@ -335,6 +337,7 @@ export function normalizeApplicantRecord(record, { job = null } = {}) {
 
   return {
     ...candidate,
+    application,
     candidateId,
     applicationId,
     candidateResolution,

--- a/tests/job-applicants.test.js
+++ b/tests/job-applicants.test.js
@@ -151,6 +151,25 @@ test("normalizeApplicantRecord preserves fallback candidate resolution metadata"
   assert.equal(applicant.reviewPayload.candidateResolution?.candidateId, "850051000000577777");
 });
 
+test("normalizeApplicantRecord preserves application lifecycle state for fallback applicants", async () => {
+  const { normalizeApplicantRecord } = await importFresh("../api/recruit/_normalize.js");
+  const applicant = normalizeApplicantRecord({
+    id: "850051000000586080",
+    Application_ID: "ZR_7_APP",
+    Full_Name: "Benjamin Bennett",
+    Email: "ben@example.com",
+    Application_Status: "Unqualified",
+    Hiring_Pipeline: "Rejected",
+    Application_Source: "LinkedIn-Basic"
+  });
+
+  assert.equal(applicant.application.status, "Unqualified");
+  assert.equal(applicant.application.stage, "Rejected");
+  assert.equal(applicant.reviewPayload.status, "Unqualified");
+  assert.equal(applicant.reviewPayload.stage, "Rejected");
+  assert.equal(applicant.reviewPayload.source, "LinkedIn-Basic");
+});
+
 test("listJobApplicants falls back to Applications when Zoho rejects job candidate relations", async () => {
   await withEnv({
     ZOHO_ACCESS_TOKEN: "access-demo",


### PR DESCRIPTION
## What
- preserve `Hiring_Pipeline` and application lifecycle state in normalized application payloads
- carry normalized application data onto fallback applicants and candidate-detail `reviewPayload`
- add regression coverage for fallback applicants with rejected lifecycle state
- document that application lifecycle state is part of the read-side contract

## Why
The live tenant does not expose questionnaire answer fields on `Applications` or `Candidates`, but it does expose rejection state via `Application_Status` and `Hiring_Pipeline`. Downstream triage needs that state to avoid treating rejected applicants as active screening candidates.

## Verification
- `npm test`
